### PR TITLE
add quantlib

### DIFF
--- a/recipes/quantlib
+++ b/recipes/quantlib
@@ -1,0 +1,4 @@
+Package: quantlib
+Version: 1.14
+Source.URL: https://github.com/shrektan/recipes/releases/download/quantlib-1.14-with-boost/quantlib-1.14-with-boost.tar.gz
+Configure: --with-boost-include=../src/quantlib-1.14/include --prefix=/usr/local/ --enable-intraday CXXFLAGS='-std=gnu++11 -O2 -stdlib=libc++ -mmacosx-version-min=10.9' DFLAGS='-stdlib=libc++ -mmacosx-version-min=10.9'


### PR DESCRIPTION
Note, according to [QuantLib installation on Mac OS X](https://www.quantlib.org/install/macosx.shtml), different OSX version may need different environment variables.

I don't know how it should be set in recipes so I just simply assume the macOS VM uses version higher than 10.11...

> On Mac OS X 10.11 (El Capitan) and later, you'll need to pass additional environment variables to `./configure` (thanks to Albert Azout for pointing it out). Run:
>
> ```
> ./configure --with-boost-include=/usr/local/include/ \
>             --with-boost-lib=/usr/local/lib/ --prefix=/usr/local/ \
>             CXXFLAGS='-O2 -stdlib=libc++ -mmacosx-version-min=10.9' \
>             LDFLAGS='-stdlib=libc++ -mmacosx-version-min=10.9'
> ```

> (mind the backslash on the end of the lines; it tells the terminal to continue on the next line. You might also discard the backslash and write the whole command on a single line.) If your Boost installation is not in `/usr/local`, change the paths above accordingly.

> On Mac OS X 10.9 (Mavericks) and 10.10 (Yosemite), you'll need to pass different environment variables. Run:

>
> ```
> ./configure --with-boost-include=/usr/local/include/ \
>             --with-boost-lib=/usr/local/lib/ --prefix=/usr/local/ \
>             CXXFLAGS='-O2 -stdlib=libstdc++ -mmacosx-version-min=10.6' \
>             LDFLAGS='-stdlib=libstdc++ -mmacosx-version-min=10.6'
> ```

> On earlier systems, it's not necessary to pass environment variables, so the command can be simplified to:

> ```
> ./configure --with-boost-include=/usr/local/include/ \
>             --with-boost-lib=/usr/local/lib/ --prefix=/usr/local/
> ```