### PR TITLE
Added boost-libs

### DIFF
--- a/recipes/boost-libs
+++ b/recipes/boost-libs
@@ -1,0 +1,4 @@
+Package: boost-libs
+Version: 1.69-0
+Source.URL: https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz
+Configure.driver: sh

--- a/recipes/boost-libs.patch
+++ b/recipes/boost-libs.patch
@@ -12,7 +12,11 @@ diff -Nru test_0.0/configure xx/configure
 +install:
 +	echo Installing from $src to \$(DESTDIR)/usr/local/boost-1.69.0
 +	mkdir -p \$(DESTDIR)/usr/local/boost-1.69.0
-+	./${src}/bootstrap.sh --prefix=\$(DESTDIR)/usr/local/boost-1.69.0
-+	./${src}/b2 install threading=multi,single link=static -j12
++	echo Copy files from source
++	cp -r ${src}/. .
++	./bootstrap.sh --prefix=\$(DESTDIR)/usr/local/boost-1.69.0 --without-icu
++	./b2 clean
++	./b2 headers
++	./b2 threading=multi,single link=static -j12 --prefix=\$(DESTDIR)/usr/local/boost-1.69.0 install
 +
 +EOF

--- a/recipes/boost-libs.patch
+++ b/recipes/boost-libs.patch
@@ -13,6 +13,6 @@ diff -Nru test_0.0/configure xx/configure
 +	echo Installing from $src to \$(DESTDIR)/usr/local/boost-1.69.0
 +	mkdir -p \$(DESTDIR)/usr/local/boost-1.69.0
 +	./${src}/bootstrap.sh --prefix=\$(DESTDIR)/usr/local/boost-1.69.0
-+	./${src}/b2 install threading=multi,single link=shared,static -j12
++	./${src}/b2 install threading=multi,single link=static -j12
 +
 +EOF

--- a/recipes/boost-libs.patch
+++ b/recipes/boost-libs.patch
@@ -1,0 +1,18 @@
+diff -Nru test_0.0/configure xx/configure
+--- test_0.0/configure	     1969-12-31 19:00:00.000000000 -0500
++++ xx/configure	     2019-04-04 14:22:40.000000000 -0400
+@@ -0,0 +1,13 @@
++#!/bin/sh
++
++src=`dirname $0`
++
++cat << EOF >> Makefile
++all:
++
++install:
++	echo Installing from $src to \$(DESTDIR)/usr/local/boost-1.69.0
++	mkdir -p \$(DESTDIR)/usr/local/boost-1.69.0
++	./${src}/bootstrap.sh --prefix=\$(DESTDIR)/usr/local/boost-1.69.0
++	./${src}/b2 install threading=multi,single link=shared,static -j12
++
++EOF


### PR DESCRIPTION
This implements the boost libraries recipe following the guidelines in boost headers to address #9.

Note: 

```
./${src}/b2 install threading=multi,single link=shared,static -j12
```

- `-j12`: sets the cores to 12 (used previously but does not carry over). 
- `install`: installs the library
- `threading`: instruction thread type
- `link`: kind of libraries generated. 

Another call to `b2` is possible with `headers` to generate the headers and, thus, potentially allowing for the combination of both the `boost-headers` and `boost-libs` recipes.

In addition, a `LIBDIR` could be set to direct where the libraries are being placed (presently in `/usr/lib/local/`).