### PR TITLE
Boost enabled

### DIFF
--- a/recipes/boost
+++ b/recipes/boost
@@ -1,0 +1,4 @@
+Package: boost
+Version: 1.73.0
+Source.URL: https://dl.bintray.com/boostorg/release/1.73.0/source/boost_1_73_0.tar.gz
+Configure.driver: sh

--- a/recipes/boost.patch
+++ b/recipes/boost.patch
@@ -15,6 +15,6 @@ diff -Nru test_0.0/configure xx/configure
 +	mkdir -p \$(DESTDIR)/usr/local
 +	mv ${src}/* .
 +	./bootstrap.sh --prefix=\$(DESTDIR)/usr/local/boost-1.73.0
-+	./b2 --prefix=\$(DESTDIR)/usr/local/boost-1.73.0 link=static install
++	./b2 --prefix=\$(DESTDIR)/usr/local/boost-1.73.0 toolset=clang-darwin link=static cxxflags='-mmacosx-version-min=10.13 -Wall -g -O2 -fPIC -fvisibility=hidden' cflags='-mmacosx-version-min=10.13 -Wall -g -O2 -fPIC -fvisibility=hidden' install
 +
 +EOF

--- a/recipes/boost.patch
+++ b/recipes/boost.patch
@@ -14,7 +14,7 @@ diff -Nru test_0.0/configure xx/configure
 +	echo Current directory $PWD
 +	mkdir -p \$(DESTDIR)/usr/local
 +	mv ${src}/* .
-+	./bootstrap.sh --prefix=\$(DESTDIR)/usr/local/boost-1.73.0
-+	./b2 --prefix=\$(DESTDIR)/usr/local/boost-1.73.0 toolset=clang-darwin link=static cxxflags='-mmacosx-version-min=10.13 -Wall -g -O2 -fPIC -fvisibility=hidden' cflags='-mmacosx-version-min=10.13 -Wall -g -O2 -fPIC -fvisibility=hidden' install
++	./bootstrap.sh --prefix=\$(DESTDIR)/usr/local
++	./b2 --prefix=\$(DESTDIR)/usr/local toolset=clang-darwin link=static cxxflags='-mmacosx-version-min=10.13 -Wall -g -O2 -fPIC -fvisibility=hidden' cflags='-mmacosx-version-min=10.13 -Wall -g -O2 -fPIC -fvisibility=hidden' install
 +
 +EOF

--- a/recipes/boost.patch
+++ b/recipes/boost.patch
@@ -10,8 +10,7 @@ diff -Nru test_0.0/configure xx/configure
 +all:
 +
 +install:
-+	echo Installing from $src to \$(DESTDIR)/usr/local/boost-1.73.0
-+	./bootstrap.sh --prefix=\$(DESTDIR)/usr/local/boost-1.73.0
++	echo Installing from $src to \$(DESTDIR)/usr/local
 +	echo Current directory $PWD
 +	echo Copying files from source here... 
 +	cp -r ${src}/. .

--- a/recipes/boost.patch
+++ b/recipes/boost.patch
@@ -1,7 +1,7 @@
 diff -Nru test_0.0/configure xx/configure
 --- test_0.0/configure	     1969-12-31 19:00:00.000000000 -0500
 +++ xx/configure	     2020-05-28 14:22:40.000000000 -0400
-@@ -0,0 +1,13 @@
+@@ -0,0 +1,16 @@
 +#!/bin/sh
 +
 +src=`dirname $0`
@@ -12,10 +12,8 @@ diff -Nru test_0.0/configure xx/configure
 +install:
 +	echo Installing from $src to \$(DESTDIR)/usr/local
 +	echo Current directory $PWD
-+	echo Copying files from source here... 
-+	cp -r ${src}/. .
-+	mkdir -p \$(DESTDIR)/usr/local/boost-1.73.0
-+	echo Installing from $src to \$(DESTDIR)/usr/local/boost-1.73.0
++	mkdir -p \$(DESTDIR)/usr/local
++	mv ${src}/* .
 +	./bootstrap.sh --prefix=\$(DESTDIR)/usr/local/boost-1.73.0
 +	./b2 --prefix=\$(DESTDIR)/usr/local/boost-1.73.0 link=static install
 +

--- a/recipes/boost.patch
+++ b/recipes/boost.patch
@@ -1,0 +1,23 @@
+diff -Nru test_0.0/configure xx/configure
+--- test_0.0/configure	     1969-12-31 19:00:00.000000000 -0500
++++ xx/configure	     2020-05-28 14:22:40.000000000 -0400
+@@ -0,0 +1,13 @@
++#!/bin/sh
++
++src=`dirname $0`
++
++cat << EOF >> Makefile
++all:
++
++install:
++	echo Installing from $src to \$(DESTDIR)/usr/local/boost-1.73.0
++	./bootstrap.sh --prefix=\$(DESTDIR)/usr/local/boost-1.73.0
++	echo Current directory $PWD
++	echo Copying files from source here... 
++	cp -r ${src}/. .
++	mkdir -p \$(DESTDIR)/usr/local/boost-1.73.0
++	echo Installing from $src to \$(DESTDIR)/usr/local/boost-1.73.0
++	./bootstrap.sh --prefix=\$(DESTDIR)/usr/local/boost-1.73.0
++	./b2 --prefix=\$(DESTDIR)/usr/local/boost-1.73.0 link=static install
++
++EOF


### PR DESCRIPTION
@s-u This PR is the long overdue successor to #10. (I can't push to it anymore.)

In short, the `boost` recipe enables a static-system wide boost installation that can be linked to per #9.

Unlike the predecessor PR, the boost build commands are greatly simplified and ensure the requirements are met with no extra flair.

```bash
./bootstrap.sh --prefix=\$(DESTDIR)/usr/local/boost-1.73.0
./b2 --prefix=\$(DESTDIR)/usr/local/boost-1.73.0 link=static install
```

As proof, please feel free to view my build via a Parallels on macOS 10.15.1: 

<img width="1411" alt="parallel-screenshot" src="https://user-images.githubusercontent.com/833642/83319252-649f0980-a202-11ea-9024-cfbc68634a2e.png">
 
Moreover, here is the built binary (~18.7 mb):

[boost-1.73.0-darwin.19-x86_64.tar.gz](https://github.com/R-macos/recipes/files/4705078/boost-1.73.0-darwin.19-x86_64.tar.gz)
