### PR TITLE
add openssl recipe

### DIFF
--- a/recipes/openssl
+++ b/recipes/openssl
@@ -1,0 +1,6 @@
+Package: openssl
+Version: 1.1.1g
+Source.URL: https://www.openssl.org/source/openssl-1.1.1g.tar.gz
+Configure.script: Configure
+Configure.darwin: darwin64-x86_64-cc enable-ec_nistp_64_gcc_128
+Configure.cfgflags: no-shared

--- a/scripts/mkmk.R
+++ b/scripts/mkmk.R
@@ -64,7 +64,7 @@ os.maj <- paste(os,gsub("\\..*","",os.ver),sep=".")
 
 cfgflags=c("--with-pic --disable-shared --enable-static")
 cfg <- function(d) {
-    f <- cfgflags
+    f <- if (length(d[["Configure.cfgflags"]])) d[["Configure.cfgflags"]] else cfgflags
     if (!is.null(d[["Configure"]])) f <- c(f, d[["Configure"]])
     if (!is.null(d[[paste0("Configure.",os)]])) f <- c(f, d[[paste0("Configure.",os)]])
     if (!is.null(d[[paste0("Configure.",os.maj)]])) f <- c(f, d[[paste0("Configure.",os.maj)]])


### PR DESCRIPTION
Replaces the (very dated) openssl headers on the macos server with a proper installation. To quote the [openssl website](https://www.openssl.org/source/):

> Note: The latest stable version is the 1.1.1 series. This is also our Long Term Support (LTS) version, supported until 11th September 2023. All older versions (including 1.1.0, 1.0.2, 1.0.0 and 0.9.8) are now out of support and should not be used. Users of these older versions are encourage to upgrade to 1.1.1 as soon as possible.

OpenSSL does not use autotools, so I had to create a new rule that lets you override the `--enable-static --disable-shared` flags, otherwise it won't build.

With this, packages like [PKI](https://cran.r-project.org/web/checks/check_results_PKI.html) and [s2](https://cran.r-project.org/web/checks/check_results_s2.html) and [openssl](https://cran.r-project.org/web/checks/check_results_openssl.html) should work, but I think you have to uninstall the libressl headers that you copied from the apple site, because they conflict and don't work with anything.