### PR TITLE
Update cairo

### DIFF
--- a/recipes/cairo
+++ b/recipes/cairo
@@ -1,5 +1,5 @@
 Package: cairo
-Version: 1.14.12
-Source.URL: https://www.cairographics.org/releases/cairo-1.14.12.tar.xz
+Version: 1.16.0
+Source.URL: https://www.cairographics.org/releases/cairo-1.16.0.tar.xz
 Depends: freetype (>= 2.1.9), fontconfig, libpng, pixman (>= 0.30.0)
 Configure: --disable-quartz-font --disable-quartz --disable-quartz-image --disable-qt


### PR DESCRIPTION
Hi would it be possible to update cairo? The current stable version 1.16.0 was released over 2 years ago. 

This is also the version that ships in the current Debian and Fedora and most other distros: https://packages.debian.org/bullseye/libcairo2-dev

There is also a 1.17.x branch but in cairo the odd branches are unstable.