### PR TITLE
add gmp C++ bindings

### DIFF
--- a/recipes/gmp
+++ b/recipes/gmp
@@ -1,6 +1,7 @@
 Package: gmp
 Version: 6.2.1
 Source.URL: https://gmplib.org/download/gmp/gmp-6.2.1.tar.xz
+Configure: --enable-cxx
 Configure.i386: ABI=32
 Configure.ppc: ABI=32
 Configure.x86_64: ABI=64


### PR DESCRIPTION
I'm submitting this PR to (hopefully) add C++ bindings for the GMP library. This PR is an updated version of PR https://github.com/R-macos/recipes/pull/18. Specifically, this PR updates the GMP recipe (i.e the `recipes/gmp` file) to add a compilation flag that will enable these bindings (i.e. `--enable-cxx`). For more information on this compilation flag, please see the [Build Options section of the GMP Manual](https://gmplib.org/manual/Build-Options) (specifically  "C++ Support, --enable-cxx" subsection).

To help verify that this PR works, I have created an [additional branch](https://github.com/jeffreyhanson/recipes/tree/gmpxx-pkg-test) and used [GitHub Actions](https://github.com/jeffreyhanson/recipes/actions/runs/910532778) to verify that (1) the updated recipe in this PR provides these bindings (please see the "Verify gmpxx build" component of the build) and (2) an R package which requires these C++ bindings can be built from source using the updated recipe file (please see the "Verify package build" component of the build).

What do you think? Please let me know if there's any further changes I can make to improve this PR?