### PR TITLE
Build freetype without harfbuzz

### DIFF
--- a/recipes/freetype
+++ b/recipes/freetype
@@ -1,5 +1,5 @@
 Package: freetype
 Depends: libpng, pkgconfig
-Version: 2.11.0
-Source.URL: http://mirror.downloadvn.com/nongnu/freetype/freetype-2.11.0.tar.xz
-Configure.darwin: --without-old-mac-fonts --without-fsspec --without-fsref --without--quickdraw-toolbox --without-quickdraw-carbon --without-ats
+Version: 2.11.1
+Source.URL: http://mirror.downloadvn.com/nongnu/freetype/freetype-2.11.1.tar.xz
+Configure.darwin: --without-harfbuzz --without-old-mac-fonts --without-fsspec --without-fsref --without--quickdraw-toolbox --without-quickdraw-carbon --without-ats


### PR DESCRIPTION
Your current version has an hidden dependency on harfbuzz (as shown from the `.pc` file and linker errors). The easiest solution is to not depend on harfbuzz (such that the flags and behavior are consistent with xquartz and other builds).

