### PR TITLE
Add a recipe for JAGS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 *~
+.DS_Store

--- a/recipes/jags
+++ b/recipes/jags
@@ -1,0 +1,6 @@
+Package: jags
+Version: 4.3.1
+Source.URL: https://sourceforge.net/projects/mcmc-jags/files/JAGS/4.x/Source/JAGS-4.3.1.tar.gz
+Configure.darwin: --with-blas='-framework Accelerate' --with-lapack='-framework Accelerate' CC=clang CXX=clang++
+Configure.x86_64: --prefix=/usr/local CFLAGS='-O2 -mmacosx-version-min=10.13' CXXFLAGS='-O2 -mmacosx-version-min=10.13' F77="/usr/local/gfortran/bin/gfortran"
+Configure.arm64: --prefix=/opt/R/arm64 CFLAGS='-O2 -mmacosx-version-min=11' CXXFLAGS='-O2 -mmacosx-version-min=11' F77="/opt/R/arm64/gfortran/bin/gfortran"

--- a/recipes/jags
+++ b/recipes/jags
@@ -1,6 +1,7 @@
 Package: jags
 Version: 4.3.1
 Source.URL: https://sourceforge.net/projects/mcmc-jags/files/JAGS/4.x/Source/JAGS-4.3.1.tar.gz
+Configure.script: configure
 Configure.darwin: --with-blas='-framework Accelerate' --with-lapack='-framework Accelerate' CC=clang CXX=clang++
 Configure.x86_64: --prefix=/usr/local CFLAGS='-O2 -mmacosx-version-min=10.13' CXXFLAGS='-O2 -mmacosx-version-min=10.13' F77="/usr/local/gfortran/bin/gfortran"
 Configure.arm64: --prefix=/opt/R/arm64 CFLAGS='-O2 -mmacosx-version-min=11' CXXFLAGS='-O2 -mmacosx-version-min=11' F77="/opt/R/arm64/gfortran/bin/gfortran"


### PR DESCRIPTION
This recipe installs JAGS so that the CRAN packages rjags & runjags (and dependencies) can be installed.

I needed to add "Configure.script: configure" to remove the --disable-shared etc flags because JAGS needs to build .so files. Specific flags are provided for darwin, x86_64 and arm64 to allow installation on these platforms (I have tested both and verified that the resultant JAGS installation works and that rjags can be installed from source).  

I have not specifically tested linux builds, but as far as I understand these should work with just a standard configure on most distros - otherwise I can ask Martin Plummer to assist for linux-specific configure flags.
