### PR TITLE
Cairo: disable X11 dependency

### DIFF
--- a/recipes/cairo
+++ b/recipes/cairo
@@ -2,4 +2,4 @@ Package: cairo
 Version: 1.16.0
 Source.URL: https://www.cairographics.org/releases/cairo-1.16.0.tar.xz
 Depends: freetype (>= 2.1.9), fontconfig, libpng, pixman (>= 0.30.0)
-Configure: --disable-quartz-font --disable-quartz --disable-quartz-image --disable-qt
+Configure: --disable-quartz-font --disable-quartz --disable-quartz-image --disable-qt --disable-xcb --disable-xlib --disable-xlib-xrender


### PR DESCRIPTION
If you currently look at the `cairo.pc` file we see hardcoded dependency on X11 (xquartz):

```
Name: cairo
Description: Multi-platform 2D graphics library
Version: 1.16.0

Requires.private: pixman-1 >= 0.30.0    fontconfig >= 2.2.95 freetype2 >= 9.7.3   libpng   
Libs: -L${libdir} -lcairo
Libs.private: -lz -lz   -lz  -lXrender  -lSM -lICE  -L/usr/X11/lib -lX11 -lXext  
Cflags: -I${includedir}/cairo
```

As a result, users that don't have xQuartz installed get a confusing loading error when loading an R package that depends on cairo directly or indirectly, for example pdftools: https://github.com/ropensci/pdftools/issues/111

I don't think the X11 dependency adds any important functionality to cairo. Let's remove it.