### PR TITLE
Add Github Action to test recipes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           fetch-depth: 0 # default is 1
           ref: "${{ github.ref }}"
-      
+
       - name: Find changed recipes
         id: find
         shell: bash
@@ -77,15 +77,15 @@ jobs:
           sudo cp stubs/pkgconfig-darwin/*.pc /usr/local/lib/pkgconfig/
 
       - name: Build R dependencies
-        if: success() && (inputs.recipes || steps.find.outputs.recipes)  
+        if: success() && (inputs.recipes || steps.find.outputs.recipes)
         run: make -C build ${{ inputs.recipes || steps.find.outputs.recipes }}
 
       - name: Collect
-        if: success() && (inputs.recipes || steps.find.outputs.recipes)  
+        if: success() && (inputs.recipes || steps.find.outputs.recipes)
         run: mkdir deploy && cp -p build/*-darwin*.tar.gz deploy/
 
       - name: Upload
-        if: success() && (inputs.recipes || steps.find.outputs.recipes)  
+        if: success() && (inputs.recipes || steps.find.outputs.recipes)
         uses: actions/upload-artifact@master
         with:
           name: recipes-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,16 @@
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      recipes:
+        description: "Which recipes to build, takes precedent"
+      all:
+        description: "Build all recipes"
+        default: false
+
+permissions:
+  contents: read
 
 name: Cook recipes
 
@@ -16,10 +28,35 @@ jobs:
 
     strategy:
       matrix:
-        os: [ 'macOS-10.15' ]
+        os: [ 'macos-11' ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # default is 1
+          ref: "${{ github.ref }}"
+      
+      - name: Find changed recipes
+        id: find
+        shell: bash
+        run: |
+          ref="${{ github.ref_name == 'master' && 'HEAD~1' || 'origin/master' }}"
+          if [ "${{ inputs.all }}" = true ]; then
+            files=`ls -d recipes/*`
+          else
+            files=`git diff --name-only $ref`
+          fi
+
+          recipes=$(echo $files |
+            tr ' ' '\n' |
+            grep 'recipes/[^\.]*$' |
+            sed 's|recipes/\(.*\)|\1|g' |
+            tr '\n' ' ')
+
+          echo $recipes
+          if [ ! -z "$recipes" ]; then
+            echo "recipes=$recipes">> $GITHUB_OUTPUT
+          fi
 
       - name: Create Makefile
         run: Rscript scripts/mkmk.R
@@ -39,13 +76,15 @@ jobs:
           sudo cp stubs/pkgconfig-darwin/*.pc /usr/local/lib/pkgconfig/
 
       - name: Build R dependencies
-        run: make -C build xz pcre2 jpeg libpng tiff
+        if: success() && (inputs.recipes || steps.find.outputs.recipes)  
+        run: make -C build ${{ inputs.recipes || steps.find.outputs.recipes }}
 
       - name: Collect
+        if: success() && (inputs.recipes || steps.find.outputs.recipes)  
         run: mkdir deploy && cp -p build/*-darwin*.tar.gz deploy/
 
       - name: Upload
-        if: success()
+        if: success() && (inputs.recipes || steps.find.outputs.recipes)  
         uses: actions/upload-artifact@master
         with:
           name: recipes-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,8 @@ jobs:
 
       - name: Remove local stuff
         run: |
-          sudo mv /usr/local /usr/disabled
-          sudo mkdir /usr/local
+          sudo mkdir /usr/local/.disabled
+          sudo mv /usr/local/* /usr/local/.disabled/
 
       - name: Build pkg-config
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Build pkg-config
         run: |
-          make -j4 -C build pkg-config
+          make -j4 -C build pkgconfig
           sudo cp stubs/pkgconfig-darwin/*.pc /usr/local/lib/pkgconfig/
 
       - name: Build all

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,9 @@ jobs:
         run: Rscript scripts/mkmk.R
 
       - name: Remove local stuff
-        run: sudo rm -rf /usr/local/*
+        run: |
+          sudo mv /usr/local /usr/disabled
+          sudo mkdir /usr/local
 
       - name: Build pkg-config
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,13 +31,15 @@ jobs:
 
       - name: Build tools
         run: |
-          make -j4 -C build pkgconfig autoconf automake
+          make -C build pkgconfig
 
       - name: Stubs
-        run: echo sudo cp stubs/pkgconfig-darwin/*.pc /usr/local/lib/pkgconfig/ && ls -l /usr/local/lib/pkgconfig/
+        run: |
+          sudo mkdir -p /usr/local/lib/pkgconfig
+          sudo cp stubs/pkgconfig-darwin/*.pc /usr/local/lib/pkgconfig/
 
       - name: Build R dependencies
-        run: make -j4 -C build xz pcre2 jpeg png tiff
+        run: make -C build xz pcre2 jpeg png tiff
 
       - name: Collect
         run: mkdir deploy && cp -p build/*-darwin*.tar.gz deploy/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
         description: "Which recipes to build, takes precedent"
       all:
         description: "Build all recipes"
+        type: boolean
         default: false
 
 permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,46 @@
+on: [push, pull_request]
+
+name: Cook recipes
+
+jobs:
+  cook:
+    runs-on: ${{ matrix.os }}
+
+    name: ${{ matrix.os }} check
+
+    env:
+      CC: clang
+      CXX: clang++
+      OBJC: clang
+      OBJCXX: clang++
+
+    strategy:
+      matrix:
+        os: [ 'macOS-10.15' ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Create Makefile
+        run: Rscript scripts/mkmk.R
+
+      - name: Remove local stuff
+        run: sudo rm -rf /usr/local/*
+
+      - name: Build pkg-config
+        run: |
+          make -j4 -C build pkg-config
+          sudo cp stubs/pkgconfig-darwin/*.pc /usr/local/lib/pkgconfig/
+
+      - name: Build all
+        run: make -j4 -C build all
+
+      - name: Collect
+        run: mkdir deploy && cp -p build/*-darwin*.tar.gz deploy/
+
+      - name: Upload
+        if: success()
+        uses: actions/upload-artifact@master
+        with:
+          name: recipes-build
+          path: deploy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
   cook:
     runs-on: ${{ matrix.os }}
 
-    name: ${{ matrix.os }} check
+    name: ${{ matrix.os }} build
 
     env:
       CC: clang
@@ -29,13 +29,15 @@ jobs:
           sudo mkdir /usr/local/.disabled
           sudo mv /usr/local/* /usr/local/.disabled/
 
-      - name: Build pkg-config
+      - name: Build tools
         run: |
-          make -j4 -C build pkgconfig
-          sudo cp stubs/pkgconfig-darwin/*.pc /usr/local/lib/pkgconfig/
+          make -j4 -C build pkgconfig autoconf automake
 
-      - name: Build all
-        run: make -j4 -C build all
+      - name: Stubs
+        run: echo sudo cp stubs/pkgconfig-darwin/*.pc /usr/local/lib/pkgconfig/ && ls -l /usr/local/lib/pkgconfig/
+
+      - name: Build R dependencies
+        run: make -j4 -C build xz pcre2 jpeg png tiff
 
       - name: Collect
         run: mkdir deploy && cp -p build/*-darwin*.tar.gz deploy/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           sudo cp stubs/pkgconfig-darwin/*.pc /usr/local/lib/pkgconfig/
 
       - name: Build R dependencies
-        run: make -C build xz pcre2 jpeg png tiff
+        run: make -C build xz pcre2 jpeg libpng tiff
 
       - name: Collect
         run: mkdir deploy && cp -p build/*-darwin*.tar.gz deploy/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 on:
   push:
+    branches:
+      - master
   pull_request:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Hello! 

This PR adds a workflow that can be used to test recipes when submitting changes or new additions. I based it on the one in feature/actions which was a great start and allowed me to quickly get the action going.

It has a manual mode that can be triggered via the gh actions UI ([here](https://github.com/R-macos/recipes/actions) once the workflow is merged) were select recipes to be build can be entered, or a build of all recipes can be triggered.

On pull_request and commits (to master) the workflow will determine the changed recipes and build only those.