### PR TITLE
Add libarchive, for the archive package

### DIFF
--- a/recipes/iconv-stub
+++ b/recipes/iconv-stub
@@ -1,0 +1,4 @@
+Package: iconv-stub
+Description: System stub for iconv
+Version: 0.1
+Source.URL: https://github.com/gaborcsardi/recipes/releases/download/latest/iconv-stub-${ver}.tar.gz

--- a/recipes/libarchive
+++ b/recipes/libarchive
@@ -1,5 +1,5 @@
 Package: libarchive
 Version: 3.7.2
 Source.URL: https://www.libarchive.org/downloads/libarchive-${ver}.tar.xz
-Depends: libb2, lz4, xz, zstd
+Depends: libb2, lz4, xz, zstd, iconv-stub
 Configure: --without-lzo2 --without-nettle --without-xml2 --without-openssl --with-expat

--- a/recipes/libarchive
+++ b/recipes/libarchive
@@ -1,0 +1,5 @@
+Package: libarchive
+Version: 3.7.2
+Source.URL: https://www.libarchive.org/downloads/libarchive-${ver}.tar.xz
+Depends: libb2, lz4, xz, zstd
+Configure: --without-lzo2 --without-nettle --without-xml2 --without-openssl --with-expat

--- a/recipes/libb2
+++ b/recipes/libb2
@@ -1,0 +1,3 @@
+Package: libb2
+Version: 0.98.1
+Source.URL: https://github.com/BLAKE2/libb2/releases/download/v${ver}/libb2-${ver}.tar.gz

--- a/recipes/lz4
+++ b/recipes/lz4
@@ -1,0 +1,5 @@
+Package: lz4
+Version: 1.9.4
+Source.URL: https://github.com/lz4/lz4/archive/v${ver}.tar.gz
+Build-system: make
+Install: make -B install

--- a/recipes/lz4.patch
+++ b/recipes/lz4.patch
@@ -1,0 +1,11 @@
+--- a/lib/Makefile
++++ b/lib/Makefile
+@@ -43,7 +43,7 @@ LIBVER_MINOR := $(shell echo $(LIBVER_MINOR_SCRIPT))
+ LIBVER_PATCH := $(shell echo $(LIBVER_PATCH_SCRIPT))
+ LIBVER  := $(shell echo $(LIBVER_SCRIPT))
+ 
+-BUILD_SHARED:=yes
++BUILD_SHARED:=no
+ BUILD_STATIC:=yes
+ 
+ CPPFLAGS+= -DXXH_NAMESPACE=LZ4_

--- a/recipes/xz
+++ b/recipes/xz
@@ -1,3 +1,3 @@
 Package: xz
-Version: 5.4.2
+Version: 5.4.4
 Source.URL: https://tukaani.org/xz/xz-${ver}.tar.gz

--- a/recipes/zstd
+++ b/recipes/zstd
@@ -1,4 +1,6 @@
 Package: zstd
-Version: 1.5.2
+Version: 1.5.5
 Source.URL: https://github.com/facebook/zstd/releases/download/v${ver}/zstd-${ver}.tar.gz
+Depends: lz4, xz
 Configure.chmod: +x
+Configure: -DZSTD_BUILD_CONTRIB=ON -DZSTD_LEGACY_SUPPORT=ON -DZSTD_ZLIB_SUPPORT=ON -DZSTD_LZMA_SUPPORT=ON -DZSTD_LZ4_SUPPORT=ON

--- a/stubs/pkgconfig-darwin/iconv.pc
+++ b/stubs/pkgconfig-darwin/iconv.pc
@@ -1,0 +1,10 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: iconv
+Description: iconv (system)
+Version: 1.11
+Libs: -L${libdir} -liconv
+Cflags: -I${includedir}


### PR DESCRIPTION
Also:
- add libarchive dependencies: libb2 and lz4.
- add stub for iconv,
- update xz version.
- update zstd version, make it depend on lz4, xz.

In general, I was trying to match the current config of the archive package with these changes, and the `configure` arguments.

(If there is a package that links to zstd, they might need to update their `PKG_LIBS` to add `-lxz` and `-llz4` now. I didn't find such a package, though.)