### PR TITLE
Add libtool to match other sysreq dbs

### DIFF
--- a/recipes/libtool
+++ b/recipes/libtool
@@ -1,0 +1,3 @@
+Package: libtool
+Version: 2.4.7
+Source.URL: https://ftp.gnu.org/gnu/libtool/libtool-${ver}.tar.gz


### PR DESCRIPTION
I need libtoolize for a package I'm preparing to submit to CRAN and have added it to the other sysreq databases-I believe this is the last one.