### PR TITLE
Recipe for libsbml v5.20.2

### DIFF
--- a/recipes/libsbml
+++ b/recipes/libsbml
@@ -1,0 +1,6 @@
+Package: libsbml
+Version: 5.20.2
+Source.URL: https://github.com/sbmlteam/libsbml/archive/refs/tags/v${ver}.tar.gz
+Depends: expat
+Configure: -DENABLE_FBC=ON -DENABLE_GROUPS=ON
+Build-system: cmake

--- a/recipes/libsbml
+++ b/recipes/libsbml
@@ -1,6 +1,6 @@
 Package: libsbml
 Version: 5.20.2
 Source.URL: https://github.com/sbmlteam/libsbml/archive/refs/tags/v${ver}.tar.gz
-Depends: expat
-Configure: -DENABLE_FBC=ON -DENABLE_GROUPS=ON
+Depends: zlib-stub
+Configure: -DENABLE_FBC=ON -DENABLE_GROUPS=ON -WITH_LIBXML=TRUE
 Build-system: cmake

--- a/recipes/libsbml
+++ b/recipes/libsbml
@@ -1,5 +1,5 @@
 Package: libsbml
 Version: 5.20.2
 Source.URL: https://github.com/sbmlteam/libsbml/archive/refs/tags/v${ver}.tar.gz
-Configure: -DENABLE_FBC=ON -DENABLE_GROUPS=ON -DWITH_LIBXML=TRUE
+Configure: -DLIBSBML_SKIP_SHARED_LIBRARY=ON -DENABLE_FBC=ON -DENABLE_GROUPS=ON -DWITH_LIBXML=TRUE
 Build-system: cmake

--- a/recipes/libsbml
+++ b/recipes/libsbml
@@ -1,6 +1,5 @@
 Package: libsbml
 Version: 5.20.2
 Source.URL: https://github.com/sbmlteam/libsbml/archive/refs/tags/v${ver}.tar.gz
-Depends: zlib-stub
-Configure: -DENABLE_FBC=ON -DENABLE_GROUPS=ON -WITH_LIBXML=TRUE
+Configure: -DENABLE_FBC=ON -DENABLE_GROUPS=ON -DWITH_LIBXML=TRUE
 Build-system: cmake


### PR DESCRIPTION
The PR adds a recipe for libsbml. 

libsbml is a library for handling text files in [Systems Biology Markup Language (SBML)](https://sbml.org/software/libsbml/). The library is a dependency of an R package ([cobrar](https://github.com/Waschina/cobrar)) that we have developed and are preparing to submit to CRAN.

The package is available for Linux build systems from the dnf and apt package managers. With this PR, I hope to make the libsbml dependency available on CRAN's MacOS build system as well.