### PR TITLE
Update libpq to fix issue with RPostgres and Redshift

### DIFF
--- a/recipes/libpq
+++ b/recipes/libpq
@@ -1,5 +1,5 @@
 Package: libpq
-Version: 14.5
+Version: 16.2
 Source.URL: https://ftp.postgresql.org/pub/source/v${ver}/postgresql-${ver}.tar.bz2
 Configure.x86_64: CFLAGS=-fPIC
 Make: make MAKELEVEL=0 -j12


### PR DESCRIPTION
Current CRAN Mac binaries of `RPostgres` are broken for (at least some instances of) Redshift (r-dbi/RPostgres#441). Compiling `RPostgres` from source against `libpq`/`postgresql` installed via Homebrew fixes the issue, so bumping the `libpq` dependency here should help.

I'm not an author of `RPostgres`, so tagging @krlmlr for more authority on this.

Right now I bumped the version number from `14.5` to `16.2`, which is the newest version. (Newest `libpq` available on Homebrew, as well as newest `postgresql` available at the [source](https://ftp.postgresql.org/pub/source/)).

In case it would be preferred to not bump major versions, `brew install postgresql` installs `postgresql@14` and version 14.11 to be exact. Compiling `RPostgres` from source against that version works too, so bumping to 14.11 should also be adequate.