### PR TITLE
Add libgit2 and dependency libssh2

### DIFF
--- a/recipes/libgit2
+++ b/recipes/libgit2
@@ -1,0 +1,7 @@
+Package: libgit2
+Version: 1.8.2
+Depends: openssl, libssh2
+Source-URL: https://github.com/libgit2/libgit2/archive/refs/tags/v${ver}.tar.gz
+Source-SHA256: 184699f0d9773f96eeeb5cb245ba2304400f5b74671f313240410f594c566a28
+Configure: -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DUSE_SSH=ON
+Build-system: cmake

--- a/recipes/libssh2
+++ b/recipes/libssh2
@@ -1,0 +1,6 @@
+Package: libssh2
+Version: 1.11.1
+Depends: openssl
+Source-URL: https://github.com/libssh2/libssh2/releases/download/libssh2-${ver}/libssh2-${ver}.tar.gz
+Source-SHA256: d9ec76cbe34db98eec3539fe2c899d26b0c837cb3eb466a56b0f109cabf658f7
+Configure: --with-openssl --with-libz


### PR DESCRIPTION
Requested by KH/BDR such that packages like git2r don't need to download static libs.