### PR TITLE
Add recipe for FLINT C library

### DIFF
--- a/recipes/flint
+++ b/recipes/flint
@@ -1,0 +1,6 @@
+Package: flint
+Version: 3.1.3-p1
+Source-URL: https://github.com/flintlib/flint/releases/download/v${ver}/flint-${ver}.tar.gz
+Source-SHA256: 96637ba9de43397d06657deefe8e6dee9d226992b5526bb1c9a9d563b983e027
+Depends: mpfr (>= 4.1.0), gmp (>= 6.2.1)
+Special: in-sources

--- a/recipes/flint.patch
+++ b/recipes/flint.patch
@@ -1,0 +1,11 @@
+diff -ruN flint-3.1.3-p1/src/double_interval.h flint-3.1.3-p1-patched/src/double_interval.h
+--- flint-3.1.3-p1/src/double_interval.h	2024-04-25 17:00:25
++++ flint-3.1.3-p1-patched/src/double_interval.h	2024-08-28 10:47:50
+@@ -183,6 +183,7 @@
+ di_t arb_get_di(const arb_t x);
+ void arb_set_di(arb_t res, di_t x, slong prec);
+ 
++static
+ DOUBLE_INTERVAL_INLINE
+ double d_randtest2(flint_rand_t state)
+ {


### PR DESCRIPTION
Continuing from our e-mail thread ("Re: Adding FLINT ..."):

Tomas and I have made progress preparing FLINT for MXE and Rtools, along the way requesting some improvements to FLINT's build system:

https://github.com/mxe/mxe/pull/3116
https://github.com/flintlib/flint/issues/2077
https://github.com/flintlib/flint/issues/2097

It is planned that these changes will be included in the next FLINT release, so I'm hopeful that we can forge ahead with adding a recipe here.  This PR aims to provide a working recipe and to document relevant issues.

The recipe in the PR uses `Special: in-sources` to temporarily work around the fact that building out of tree is not supported in the current FLINT release.  That can be removed as soon as it becomes possible to upgrade.

The patch file in the PR resolves a bug in the library's _tests_ causing `make check` to fail with a linker error.  I observe the error locally (Xcode 15), but none of their runners reproduce it.  (There are macOS runners but they may not be using the native toolchain.)  The patch file is optional for the build itself and should become redundant soon enough:

https://github.com/flintlib/flint/issues/2058

Under Xcode 14, `make check` was seen to fail at an earlier stage because Apple Clang was producing wrong assembly for one of the tests.  That seems to be fixed in Xcode 15.

https://github.com/flintlib/flint/issues/2048

IIUC, Xcode 14 is still used to build R binaries and external libraries for macOS.  There is no evidence yet that this issue affects the functionality of my [R package](https://github.com/jaganmn/flint), though that could change as the interface and test suite grow.  Well, by that time, you may already have moved to Xcode 15 ...