### PR TITLE
Add c-blosc to gdal recipe

### DIFF
--- a/recipes/c-blosc
+++ b/recipes/c-blosc
@@ -1,0 +1,5 @@
+Package: c-blosc
+Version: 1.21.6
+Source-URL: https://github.com/Blosc/c-blosc/archive/refs/tags/v${ver}.tar.gz
+Source-SHA256: 9fcd60301aae28f97f1301b735f966cc19e7c49b6b4321b839b4579a0c156f38
+Build-system: cmake

--- a/recipes/gdal
+++ b/recipes/gdal
@@ -1,6 +1,6 @@
 Package: gdal
 Version: 3.5.3
-Depends: pkgconfig, xz, libpq, proj, openjpeg, libwebp, libgeotiff, freexl, sqlite3, expat, hdf4, hdf5, szip, netcdf, geos, unixodbc
+Depends: pkgconfig, xz, libpq, proj, openjpeg, libwebp, libgeotiff, freexl, sqlite3, expat, hdf4, hdf5, szip, netcdf, geos, unixodbc, c-blosc
 Source-URL: https://github.com/OSGeo/gdal/releases/download/v${ver}/gdal-${ver}.tar.gz
 Source-SHA256: a9ea0300d17e35bab71df4f16e62bb2fb8081caf994ab3ee0502ce4cf0d4e593
 Configure: --with-proj-extra-lib-for-test="`pkg-config --static --libs proj` -lsz" --with-freexl=/${prefix} --with-expat=/${prefix} --with-liblzma --with-sqlite3=/${prefix}


### PR DESCRIPTION
I successfully built the `c-blosc` recipe with `./build.sh c-blosc`. I tried to build gdal, but it failed with errors: 

```
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
ld: warning: -bind_at_load is deprecated on macOS
ld: warning: ignoring duplicate libraries: '-lc++'
make: *** [gdalenhance] Error 1
Undefined symbols for architecture arm64:
  "_iconv", referenced from:
      _common_open in libfreexl.a[2](freexl.o)
      _get_workbook_stream in libfreexl.a[2](freexl.o)
      _convert_to_utf8 in libfreexl.a[2](freexl.o)
      _parse_SST in libfreexl.a[2](freexl.o)
      _parse_unicode_string in libfreexl.a[2](freexl.o)
      _ansi_to_unicode_copy in libodbc.a[121](__info.o)
      _unicode_to_ansi_copy in libodbc.a[121](__info.o)
      ...
  "_iconv_close", referenced from:
      _destroy_workbook in libfreexl.a[2](freexl.o)
      _destroy_workbook in libfreexl.a[2](freexl.o)
      _biff_set_utf8_converter in libfreexl.a[2](freexl.o)
      _search_for_pool in libodbc.a[19](SQLConnect.o)
      _search_for_pool in libodbc.a[19](SQLConnect.o)
      _unicode_setup in libodbc.a[121](__info.o)
      _unicode_setup in libodbc.a[121](__info.o)
      ...
  "_iconv_open", referenced from:
      _common_open in libfreexl.a[2](freexl.o)
      _biff_set_utf8_converter in libfreexl.a[2](freexl.o)
      _unicode_setup in libodbc.a[121](__info.o)
      _unicode_setup in libodbc.a[121](__info.o)
      _unicode_setup in libodbc.a[121](__info.o)
      _unicode_setup in libodbc.a[121](__info.o)
ld: symbol(s) not found for architecture arm64
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [gdaltransform] Error 1
make: *** [apps-target] Error 2
make: *** [gdal-3.5.3-dst] Error 2
```

I am pretty sure those errors are unrelated to `c-blosc`, and it looks like blosc was included in the previous build steps while building gdal.

(Maybe?) closes #59 