### PR TITLE
Added libopenmpt and its dependencies

### DIFF
--- a/recipes/flac
+++ b/recipes/flac
@@ -1,0 +1,5 @@
+Package: flac
+Version: 1.4.3
+Source-URL: https://downloads.xiph.org/releases/flac/flac-${ver}.tar.xz
+Source-SHA256: 6c58e69cd22348f441b861092b825e591d0b822e106de6eb0ee4d05d27205b70
+Depends: libogg

--- a/recipes/lame
+++ b/recipes/lame
@@ -1,0 +1,5 @@
+Package: lame
+Version: 3.100
+Source-URL: ttps://downloads.sourceforge.net/project/lame/lame/${ver}/lame-${ver}.tar.gz
+Source-SHA256: ddfe36cab873794038ae2c1210557ad34857a4b6bdc515785d1da9e175b1da1e
+

--- a/recipes/libogg
+++ b/recipes/libogg
@@ -1,0 +1,4 @@
+Package: libogg
+Version: 1.3.5
+Source-URL: https://ftp.osuosl.org/pub/xiph/releases/ogg/libogg-${ver}.tar.gz
+Source-SHA256: 0eb4b4b9420a0f51db142ba3f9c64b333f826532dc0f48c6410ae51f4799b664

--- a/recipes/libopenmpt
+++ b/recipes/libopenmpt
@@ -1,0 +1,5 @@
+Package: portaudio
+Version: 0.7.13
+Source-URL: https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-${ver}+release.autotools.tar.gz
+Source-SHA256: dcd7cde4f9c498eb496c4556e1c1b81353e2a74747e8270a42565117ea42e1f1
+Depends: flac, libogg, libsndfile, libvorbis, mpg123, portaudio, pulseaudio

--- a/recipes/libsndfile
+++ b/recipes/libsndfile
@@ -1,5 +1,6 @@
 Package: libsndfile
-Version: 1.1.0
-Depends: pkgconfig
+Version: 1.2.2
 Source-URL: https://github.com/libsndfile/libsndfile/releases/download/${ver}/libsndfile-${ver}.tar.xz
-Source-SHA256: 0f98e101c0f7c850a71225fb5feaf33b106227b3d331333ddc9bacee190bcf41
+Source-SHA256: 3799ca9924d3125038880367bf1468e53a1b7e3686a934f098b7e1d286cdb80e
+Depends: flac, lame, libogg, libvorbis, mpg123, opus
+

--- a/recipes/libsoxr
+++ b/recipes/libsoxr
@@ -1,0 +1,5 @@
+Package: libsoxr
+Version: 0.1.3
+Source-URL: https://downloads.sourceforge.net/project/soxr/soxr-${ver}-Source.tar.xz
+Source-SHA256: b111c15fdc8c029989330ff559184198c161100a59312f5dc19ddeb9b5a15889
+

--- a/recipes/libtool
+++ b/recipes/libtool
@@ -1,0 +1,4 @@
+Package: libtool
+Version: 2.5.4
+Source-URL: https://ftp.gnu.org/gnu/libtool/libtool-${ver}.tar.xz
+Source-SHA256: f81f5860666b0bc7d84baddefa60d1cb9fa6fceb2398cc3baca6afaa60266675

--- a/recipes/libvorbis
+++ b/recipes/libvorbis
@@ -1,0 +1,5 @@
+Package: libvorbis
+Version: 1.3.7
+Source-URL: https://downloads.xiph.org/releases/vorbis/libvorbis-${ver}.tar.xz
+Source-SHA256: b33cc4934322bcbf6efcbacf49e3ca01aadbea4114ec9589d1b1e9d20f72954b
+Depends: libogg

--- a/recipes/mpg123
+++ b/recipes/mpg123
@@ -1,0 +1,4 @@
+Package: mpg123
+Version: 1.32.10
+Source-URL: https://www.mpg123.de/download/mpg123-${ver}.tar.bz2
+Source-SHA256: 87b2c17fe0c979d3ef38eeceff6362b35b28ac8589fbf1854b5be75c9ab6557c

--- a/recipes/opus
+++ b/recipes/opus
@@ -1,0 +1,6 @@
+Package: opus
+Version: 1.5.2
+Source-URL: https://ftp.osuosl.org/pub/xiph/releases/opus/opus-${ver}.tar.gz
+Source-SHA256: 65c1d2f78b9f2fb20082c38cbe47c951ad5839345876e46941612ee87f9a7ce1
+
+

--- a/recipes/orc
+++ b/recipes/orc
@@ -1,0 +1,4 @@
+Package: orc
+Version: 0.4.40
+Source-URL: https://gstreamer.freedesktop.org/src/orc/orc-${ver}.tar.xz
+Source-SHA256: 3fc2bee78dfb7c41fd9605061fc69138db7df007eae2f669a1f56e8bacef74ab

--- a/recipes/portaudio
+++ b/recipes/portaudio
@@ -1,0 +1,4 @@
+Package: portaudio
+Version: 19.7.0
+Source-URL: https://files.portaudio.com/archives/pa_stable_v190700_20210406.tgz
+Source-SHA256: 47efbf42c77c19a05d22e627d42873e991ec0c1357219c0d74ce6a2948cb2def

--- a/recipes/pulseaudio
+++ b/recipes/pulseaudio
@@ -1,0 +1,5 @@
+Package: pulseaudio
+Version: 17.0
+Source-URL: https://www.freedesktop.org/software/pulseaudio/releases/pulseaudio-${ver}.tar.xz
+Source-SHA256: 053794d6671a3e397d849e478a80b82a63cb9d8ca296bd35b73317bb5ceb87b5
+Depends: glib, libsndfile, libsoxr, libtool, openssl, orc, speexdsp, gettext

--- a/recipes/speexspd
+++ b/recipes/speexspd
@@ -1,0 +1,4 @@
+Package: speexdsp
+Version: 1.2.1
+Source-URL: https://github.com/xiph/speexdsp/archive/refs/tags/SpeexDSP-${ver}.tar.gz
+Source-SHA256: d17ca363654556a4ff1d02cc13d9eb1fc5a8642c90b40bd54ce266c3807b91a7


### PR DESCRIPTION
I'd like to use the preferred way of including the static libopenmpt library in this R package:

https://github.com/pepijn-devries/openmpt

For this purpose I've prepared this PR with recipes for the library and its dependencies. I was not able to test them.