### PR TITLE
Add recipes for gmp, cln, and ginac

### DIFF
--- a/recipes/cln
+++ b/recipes/cln
@@ -1,0 +1,5 @@
+Package: cln
+Version: 1.3.7
+Source-URL: https://www.ginac.de/CLN/cln-${ver}.tar.bz2
+Source-SHA256: 7c7ed8474958337e4df5bb57ea5176ad0365004cbb98b621765bc4606a10d86b
+Depends: gmp

--- a/recipes/ginac
+++ b/recipes/ginac
@@ -1,0 +1,5 @@
+Package: ginac
+Version: 1.8.10
+Source-URL: https://www.ginac.de/ginac-${ver}.tar.bz2
+Source-SHA256: 6cac1973a5325de0b9bcb8e392988ae95fbc37aa66c0f1f1d3b8e64c08cec1b9
+Depends: cln, gmp


### PR DESCRIPTION
	•	Added new recipes: cln, ginac (CLN depends on GMP; GiNaC depends on CLN/GMP).
	•	Versions:  CLN 1.3.7, GiNaC 1.8.10.
	•	Local test: ./build.sh ginac on macOS arm64 (installs under /opt/R/arm64).
	•	Motivation: external libraries needed for CRAN macOS builds of the R package finitization.