### PR TITLE
cook.yml: use macos-15-intel

### DIFF
--- a/.github/workflows/cook.yml
+++ b/.github/workflows/cook.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'macos-13', 'macos-14' ]
+        os: [ 'macos-14', 'macos-15-intel' ]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
macos-13 was removed from GHA.